### PR TITLE
More code quality fixes

### DIFF
--- a/R/beta_dis.R
+++ b/R/beta_dis.R
@@ -57,7 +57,7 @@ if ('C' %in% metric){
   CqNs <- c()
   for(i in c(1:betan)){
   CqNs <- c(CqNs,CqN(betas[i],qvalue,Ns[i]))
-  names(CqNs)[i] <- paste("L",paste(i,i+1,sep="_"),sep="")
+  names(CqNs)[i] <- paste0("L",paste(i,i+1,sep="_"))
   }
   if (type == "dissimilarity"){
     rCqNs <- 1 - CqNs
@@ -72,7 +72,7 @@ if ('U' %in% metric){
   UqNs <- c()
   for(i in c(1:betan)){
   UqNs <- c(UqNs,UqN(betas[i],qvalue,Ns[i]))
-  names(UqNs)[i] <- paste("L",paste(i,i+1,sep="_"),sep="")
+  names(UqNs)[i] <- paste0("L",paste(i,i+1,sep="_"))
   }
   if (type == "dissimilarity"){
     rUqNs <- 1 - UqNs
@@ -87,7 +87,7 @@ if ('V' %in% metric){
   VqNs <- c()
   for(i in c(1:betan)){
   VqNs <- c(VqNs,VqN(betas[i],Ns[i]))
-  names(VqNs)[i] <- paste("L",paste(i,i+1,sep="_"),sep="")
+  names(VqNs)[i] <- paste0("L",paste(i,i+1,sep="_"))
   }
   if (type == "dissimilarity"){
     rVqNs <- 1 - VqNs
@@ -102,7 +102,7 @@ if ('S' %in% metric){
   SqNs <- c()
   for(i in c(1:betan)){
   SqNs <- c(SqNs,SqN(betas[i],Ns[i]))
-  names(SqNs)[i] <- paste("L",paste(i,i+1,sep="_"),sep="")
+  names(SqNs)[i] <- paste0("L",paste(i,i+1,sep="_"))
   }
   if (type == "dissimilarity"){
     rSqNs <- 1 - SqNs

--- a/R/copy_filt.R
+++ b/R/copy_filt.R
@@ -21,7 +21,7 @@ copy_filt <- function(abund,threshold,filter){
   if(missing(filter)){filter=TRUE}
   if(is.null(dim(abund)) == FALSE){
   #It is an OTU table (multiple samples)
-  sapply(1:ncol(abund), function(colnum){temp = abund[,colnum]
+  sapply(seq_len(ncol(abund)), function(colnum){temp = abund[,colnum]
     if(threshold == round(threshold)){
     #Absolute
     rownums = which(temp < threshold)

--- a/R/dis_nmds.R
+++ b/R/dis_nmds.R
@@ -39,9 +39,9 @@ if(missing(plot)){plot = "NMDS"}
 if(missing(centroids)){centroids = FALSE}
 if(missing(legend)){legend = TRUE}
 if(missing(labels)){labels = "none"}
-if((centroids == TRUE) & missing(hierarchy))stop("A hierarchy table is necessary to draw centroids.")
-if((labels == "group") & missing(hierarchy))stop("A hierarchy table is necessary to print group names.")
-if((labels == "both") & missing(hierarchy))stop("A hierarchy table is necessary to print group names.")
+if((centroids == TRUE) && missing(hierarchy))stop("A hierarchy table is necessary to draw centroids.")
+if((labels == "group") && missing(hierarchy))stop("A hierarchy table is necessary to print group names.")
+if((labels == "both") && missing(hierarchy))stop("A hierarchy table is necessary to print group names.")
 if(missing(runs)){runs = 100}
 
 
@@ -66,7 +66,7 @@ if(!missing(hierarchy)){
   }
 }
 
-if(missing(hierarchy) & (length(colour) != 1))stop("The colour vector can only contain one value when not specifying a hierarchy table")
+if(missing(hierarchy) && (length(colour) != 1))stop("The colour vector can only contain one value when not specifying a hierarchy table")
 
 ######
 # NMDS plot

--- a/R/div_part.R
+++ b/R/div_part.R
@@ -75,7 +75,7 @@ if(is.nested(hierarchy) == FALSE) stop("The groups in the hierarchy table are no
 
 #Count number of levels
 leveln <- ncol(hierarchy)
-levels <- paste(rep("L",leveln+1),seq(1:(leveln+1)),sep="")
+levels <- paste0(rep("L",leveln+1),seq(1:(leveln+1)))
 
 #Convert hierarchy columns to character
 hierarchy[] <- lapply(hierarchy, as.character)
@@ -129,14 +129,14 @@ beta.vector <- c()
 N.vector <- c()
 for(b in c(1:(leveln))){
 beta <- div.vector[b+1]/div.vector[b]
-names(beta) <- paste("B",paste(b,b+1,sep="_"),sep="")
+names(beta) <- paste0("B",paste(b,b+1,sep="_"))
 beta.vector <- c(beta.vector,beta)
 N <- ncol(count.tables[[b]])
 N.vector <- c(N.vector,N)
 }
 
 N.vector <- c(N.vector,1)
-names(N.vector) <- paste(rep("N",leveln+1),seq(1:(leveln+1)),sep="")
+names(N.vector) <- paste0(rep("N",leveln+1),seq(1:(leveln+1)))
 
 #Return values
 if (qvalue==0.99999) {qvalue=1}

--- a/R/div_profile_plot.R
+++ b/R/div_profile_plot.R
@@ -48,7 +48,7 @@ colour <- colorRampPalette(brewer.pal(12, "Paired"))(ncol(profile))
 
 #Single sample/group
 if(inputtype == "onesample"){
-  if(length(colour != 1)){colour="#99cc00"}
+  if(length(colour) != 1){colour="#99cc00"}
   profile.melted <- as.data.frame(cbind(names(profile),profile))
   colnames(profile.melted) <- c("Order","Profile")
   profile.melted[,1] <- as.numeric(as.character(profile.melted[,1]))

--- a/R/div_test.R
+++ b/R/div_test.R
@@ -53,7 +53,7 @@ div.values.groups$Group <- as.factor(div.values.groups$Group)
 #Data distribution (normality and homogeneity) assessment
 shapiro <- shapiro.test(div.values.groups$Value)
 barlett <- bartlett.test(Value ~ Group, data= div.values.groups)
-if((shapiro$p.value >= 0.05) & (barlett$p.value >= 0.05)){
+if((shapiro$p.value >= 0.05) && (barlett$p.value >= 0.05)){
 norm.homo=TRUE
 }else{
 norm.homo=FALSE

--- a/R/div_test_plot.R
+++ b/R/div_test_plot.R
@@ -28,7 +28,7 @@
 div_test_plot <- function(divtest,chart,colour,posthoc,threshold){
 if(missing(chart)){chart="box"}
 if(missing(posthoc)){posthoc=FALSE}
-if((names(divtest)[1] != "data") & (names(divtest)[2] != "normality.pvalue")) stop("The input object does not seem to be a div_test output.")
+if((names(divtest)[1] != "data") && (names(divtest)[2] != "normality.pvalue")) stop("The input object does not seem to be a div_test output.")
 
 #Get data table
 divtestdata <- divtest$data

--- a/R/index_div.R
+++ b/R/index_div.R
@@ -39,8 +39,8 @@ index_div <- function(abund,tree,index){
 
 #Data input control
 if(missing(abund)) stop("Abundance data is missing")
-if(missing(index) & missing(tree)){index="richness"}
-if(missing(index) & !missing(tree)){index="faith"}
+if(missing(index) && missing(tree)){index="richness"}
+if(missing(index) && !missing(tree)){index="faith"}
 
 #Input data type identification
 if(is.null(dim(abund)) == TRUE){

--- a/R/match_data.R
+++ b/R/match_data.R
@@ -27,10 +27,10 @@ if(missing(silent)){silent=FALSE}
   tree.otus <- tree$tip.label
 
 if(missing(output)){
-  if((length(setdiff(tree.otus,countable.otus)) == 0) & (length(setdiff(countable.otus,tree.otus)) == 0)){message("OTUs in the OTU table and OTU tree match perfectly.")}
-  if((length(setdiff(tree.otus,countable.otus)) > 0) & (length(setdiff(countable.otus,tree.otus)) == 0)){message("The OTU tree contains OTUs absent in the OTU table. Filter the OTU tree")}
-  if((length(setdiff(tree.otus,countable.otus)) == 0) & (length(setdiff(countable.otus,tree.otus)) > 0)){message("The OTU table contains OTUs absent in the OTU tree. Filter the OTU table")}
-  if((length(setdiff(tree.otus,countable.otus)) > 0) & (length(setdiff(countable.otus,tree.otus)) > 0)){message("The OTU table contains OTUs absent in the OTU tree and the OTU tree contains OTUs absent in the OTU table. Filter both files")}
+  if((length(setdiff(tree.otus,countable.otus)) == 0) && (length(setdiff(countable.otus,tree.otus)) == 0)){message("OTUs in the OTU table and OTU tree match perfectly.")}
+  if((length(setdiff(tree.otus,countable.otus)) > 0) && (length(setdiff(countable.otus,tree.otus)) == 0)){message("The OTU tree contains OTUs absent in the OTU table. Filter the OTU tree")}
+  if((length(setdiff(tree.otus,countable.otus)) == 0) && (length(setdiff(countable.otus,tree.otus)) > 0)){message("The OTU table contains OTUs absent in the OTU tree. Filter the OTU table")}
+  if((length(setdiff(tree.otus,countable.otus)) > 0) && (length(setdiff(countable.otus,tree.otus)) > 0)){message("The OTU table contains OTUs absent in the OTU tree and the OTU tree contains OTUs absent in the OTU table. Filter both files")}
   output="NA"
 }
 
@@ -51,7 +51,7 @@ if(output == "countable"){
     }
     return(countable.filt)
   }
-  if((length(setdiff(tree.otus,countable.otus)) == 0) & (length(setdiff(countable.otus,tree.otus)) == 0)){
+  if((length(setdiff(tree.otus,countable.otus)) == 0) && (length(setdiff(countable.otus,tree.otus)) == 0)){
     if(silent == FALSE){
     message("OTUs/ASVs in the count table and tree match perfectly. No new count table was created.")
     }
@@ -77,7 +77,7 @@ if(output == "tree"){
     }
     return(tree)
   }
-  if((length(setdiff(tree.otus,countable.otus)) == 0) & (length(setdiff(countable.otus,tree.otus)) == 0)){
+  if((length(setdiff(tree.otus,countable.otus)) == 0) && (length(setdiff(countable.otus,tree.otus)) == 0)){
     if(silent == FALSE){
     message("OTUs/ASVs in the tree and count table match perfectly. No new tree was created.")
     }

--- a/R/pair_dis.R
+++ b/R/pair_dis.R
@@ -101,7 +101,7 @@ leveln <- ncol(hierarchy)
 }else{
 leveln <- 1
 }
-levels <- paste(rep("L",leveln),seq(1:leveln),sep="")
+levels <- paste0(rep("L",leveln),seq(1:leveln))
 if(!missing(hierarchy)){
   hierarchy[] <- lapply(hierarchy, as.character)
   colnames(hierarchy) <- levels
@@ -187,11 +187,11 @@ if('V' %in% metric){results <- append(results, list(VqN=VqN.matrix))}
 if('S' %in% metric){results <- append(results, list(SqN=SqN.matrix))}
 
 #Append matrix names
-names <- c(names,paste(paste("L",i,sep=""),"beta",sep="_"))
-if('C' %in% metric){names <- c(names,paste(paste("L",i,sep=""),"CqN",sep="_"))}
-if('U' %in% metric){names <- c(names,paste(paste("L",i,sep=""),"UqN",sep="_"))}
-if('V' %in% metric){names <- c(names,paste(paste("L",i,sep=""),"VqN",sep="_"))}
-if('S' %in% metric){names <- c(names,paste(paste("L",i,sep=""),"SqN",sep="_"))}
+names <- c(names,paste(paste0("L",i),"beta",sep="_"))
+if('C' %in% metric){names <- c(names,paste(paste0("L",i),"CqN",sep="_"))}
+if('U' %in% metric){names <- c(names,paste(paste0("L",i),"UqN",sep="_"))}
+if('V' %in% metric){names <- c(names,paste(paste0("L",i),"VqN",sep="_"))}
+if('S' %in% metric){names <- c(names,paste(paste0("L",i),"SqN",sep="_"))}
 }
 
 #Modify names

--- a/R/pair_dis_plot.R
+++ b/R/pair_dis_plot.R
@@ -54,7 +54,7 @@ if(!missing(hierarchy)){
 	colour <- getPalette(ncol(distance))
 }
 
-if(type == "NMDS" | type == "Shepard"){
+if(type == "NMDS" || type == "Shepard"){
 #NMDS plot
 values.NMDS<-metaMDS(as.dist(distance), k = 2, trymax = 400)
 if(missing(hierarchy)){


### PR DESCRIPTION
Follow-up to #4 to apply more fixes identified by `lintr::lint_package(linters = lintr::all_linter())`. These fix more mistake-prone usages similar to how `class_equals_linter()` works in #4.